### PR TITLE
Fixed errors that prevent building the world.

### DIFF
--- a/Packages/sh.orels.fast-reflection-placer/Editor/ORL.FRP.Editor.asmdef
+++ b/Packages/sh.orels.fast-reflection-placer/Editor/ORL.FRP.Editor.asmdef
@@ -1,3 +1,6 @@
 {
-	"name": "ORL.FRP.Editor"
+	"name": "ORL.FRP.Editor",
+	"includePlatforms": [
+		"Editor"
+	]
 }


### PR DESCRIPTION
Example: `error CS0234: The type or namespace name 'EditorTools' does not exist in the namespace 'UnityEditor' (are you missing an assembly reference?)`